### PR TITLE
FIN-8 Himmelsrichtung-Berechnung für Fundmeldungen

### DIFF
--- a/migrations/Version20250903123718.php
+++ b/migrations/Version20250903123718.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250903123718 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE founds_image ADD direction_to_church_or_center VARCHAR(10) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE founds_image DROP direction_to_church_or_center');
+    }
+}

--- a/src/Command/CalculateBearingCommand.php
+++ b/src/Command/CalculateBearingCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\FoundsImage;
+use App\Repository\FoundsImageRepository;
+use App\Service\GeoService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:calculate-bearing',
+    description: 'Berechnet die Himmelsrichtung für alle vorhandenen Fundmeldungen',
+)]
+class CalculateBearingCommand extends Command
+{
+    public function __construct(
+        private FoundsImageRepository $foundsImageRepository,
+        private GeoService $geoService,
+        private EntityManagerInterface $entityManager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Zeigt nur an, was geändert würde, ohne zu speichern')
+            ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'Begrenzt die Anzahl der zu verarbeitenden Bilder', 100)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = $input->getOption('dry-run');
+        $limit = (int) $input->getOption('limit');
+
+        $io->title('Himmelsrichtung-Berechnung für Fundmeldungen');
+
+        // Finde alle Bilder ohne Himmelsrichtung
+        $images = $this->foundsImageRepository->createQueryBuilder('f')
+            ->where('f.directionToChurchOrCenter IS NULL')
+            ->andWhere('f.latitude IS NOT NULL')
+            ->andWhere('f.longitude IS NOT NULL')
+            ->andWhere('f.latitude != 0')
+            ->andWhere('f.longitude != 0')
+            ->andWhere('f.churchOrCenterName IS NOT NULL')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        if (empty($images)) {
+            $io->success('Alle Fundmeldungen haben bereits eine Himmelsrichtung berechnet!');
+            return Command::SUCCESS;
+        }
+
+        $io->info(sprintf('Gefunden: %d Fundmeldungen ohne Himmelsrichtung', count($images)));
+
+        if ($dryRun) {
+            $io->note('DRY-RUN Modus: Es werden keine Änderungen gespeichert');
+        }
+
+        $progressBar = $io->createProgressBar(count($images));
+        $progressBar->start();
+
+        $updated = 0;
+        $errors = 0;
+
+        foreach ($images as $image) {
+            try {
+                // Extrahiere Koordinaten aus dem churchOrCenterName
+                $churchOrCenterName = $image->churchOrCenterName;
+                if (!$churchOrCenterName) {
+                    $progressBar->advance();
+                    continue;
+                }
+
+                // Bestimme die Zielkoordinaten basierend auf dem Namen
+                $targetLat = null;
+                $targetLon = null;
+
+                if (strpos($churchOrCenterName, 'Kirche:') === 0) {
+                    // Für Kirchen: Suche die nächste Kirche
+                    $nearestChurch = $this->geoService->findNearestChurch($image->latitude, $image->longitude);
+                    if ($nearestChurch && isset($nearestChurch['latitude'], $nearestChurch['longitude'])) {
+                        $targetLat = $nearestChurch['latitude'];
+                        $targetLon = $nearestChurch['longitude'];
+                    }
+                } elseif (strpos($churchOrCenterName, 'Ort:') === 0) {
+                    // Für Orte: Suche den nächsten Ortskern
+                    $nearestTown = $this->geoService->getNearestTown($image->latitude, $image->longitude);
+                    if ($nearestTown && isset($nearestTown['latitude'], $nearestTown['longitude'])) {
+                        $targetLat = $nearestTown['latitude'];
+                        $targetLon = $nearestTown['longitude'];
+                    }
+                }
+
+                if ($targetLat && $targetLon) {
+                    // Berechne die Himmelsrichtung
+                    $direction = $this->geoService->calculateBearing(
+                        $image->latitude,
+                        $image->longitude,
+                        $targetLat,
+                        $targetLon
+                    );
+
+                    if (!$dryRun) {
+                        $image->directionToChurchOrCenter = $direction;
+                        $this->entityManager->persist($image);
+                    }
+
+                    $updated++;
+                } else {
+                    $errors++;
+                }
+
+            } catch (\Exception $e) {
+                $errors++;
+                $io->warning(sprintf('Fehler bei Bild ID %d: %s', $image->getId(), $e->getMessage()));
+            }
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $io->newLine(2);
+
+        if (!$dryRun && $updated > 0) {
+            $this->entityManager->flush();
+        }
+
+        $io->success(sprintf(
+            'Abgeschlossen! %d Bilder aktualisiert, %d Fehler',
+            $updated,
+            $errors
+        ));
+
+        if ($dryRun) {
+            $io->note('Führen Sie den Befehl ohne --dry-run aus, um die Änderungen zu speichern');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/FinderAbstractController.php
+++ b/src/Controller/FinderAbstractController.php
@@ -11,9 +11,15 @@ class FinderAbstractController extends SymfonyAbstractController
 
     public function getUserFullName():string
     {
-        return $this->getUser() && $this->getUser()->vorname && $this->getUser()->nachname
-            ? $this->getUser()->vorname . ' ' . $this->getUser()->nachname
-            : 'anonymous';
+        $user = $this->getUser();
+        if ($user && method_exists($user, 'getVorname') && method_exists($user, 'getNachname')) {
+            $vorname = $user->getVorname();
+            $nachname = $user->getNachname();
+            if ($vorname && $nachname) {
+                return $vorname . ' ' . $nachname;
+            }
+        }
+        return 'anonymous';
     }
 
 }

--- a/src/Entity/FoundsImage.php
+++ b/src/Entity/FoundsImage.php
@@ -39,6 +39,8 @@ class FoundsImage
     public ?float             $distanceToChurchOrCenter = NULL; // Gemarkung
     #[ORM\Column(type: 'string', length: 255, nullable: TRUE)]
     public ?string            $churchOrCenterName       = NULL; // Landkreis
+    #[ORM\Column(type: 'string', length: 10, nullable: TRUE)]
+    public ?string            $directionToChurchOrCenter = NULL; // Himmelsrichtung
     #[ORM\Column(type: 'string', length: 255, nullable: TRUE)]
     public ?string            $cameraModel              = NULL; // Bundesland
     #[ORM\Column(type: 'string', length: 255, nullable: TRUE)]

--- a/src/Service/GeoService.php
+++ b/src/Service/GeoService.php
@@ -217,6 +217,74 @@ EOT;
         return $earthRadius * $c;
     }
 
+    /**
+     * Berechnet die Himmelsrichtung von einem Punkt zu einem anderen
+     * 
+     * @param float $lat1 // Standort (von)
+     * @param float $lon1 // Standort (von)
+     * @param float $lat2 // Ziel (zu)
+     * @param float $lon2 // Ziel (zu)
+     * @return string Himmelsrichtung (N, NO, O, SO, S, SW, W, NW)
+     */
+    public function calculateBearing(float $lat1, float $lon1, float $lat2, float $lon2): string
+    {
+        // Konvertiere Grad zu Radiant
+        $lat1Rad = deg2rad($lat1);
+        $lat2Rad = deg2rad($lat2);
+        $dLonRad = deg2rad($lon2 - $lon1);
+
+        // Berechne den Bearing (Azimut)
+        $y = sin($dLonRad) * cos($lat2Rad);
+        $x = cos($lat1Rad) * sin($lat2Rad) - sin($lat1Rad) * cos($lat2Rad) * cos($dLonRad);
+        
+        $bearing = atan2($y, $x);
+        
+        // Konvertiere von Radiant zu Grad und normalisiere auf 0-360°
+        $bearingDegrees = rad2deg($bearing);
+        $bearingDegrees = fmod($bearingDegrees + 360, 360);
+
+        // Konvertiere zu Himmelsrichtung
+        return $this->degreesToCompass($bearingDegrees);
+    }
+
+    /**
+     * Konvertiert Grad in Himmelsrichtung
+     * 
+     * @param float $degrees
+     * @return string
+     */
+    private function degreesToCompass(float $degrees): string
+    {
+        $directions = [
+            'N' => [348.75, 11.25],
+            'NO' => [11.25, 33.75],
+            'O' => [33.75, 56.25],
+            'SO' => [56.25, 78.75],
+            'S' => [78.75, 101.25],
+            'SW' => [101.25, 123.75],
+            'W' => [123.75, 146.25],
+            'NW' => [146.25, 168.75],
+            'N2' => [168.75, 191.25], // N (180-191.25)
+            'NW2' => [191.25, 213.75], // NW (191.25-213.75)
+            'W2' => [213.75, 236.25], // W (213.75-236.25)
+            'SW2' => [236.25, 258.75], // SW (236.25-258.75)
+            'S2' => [258.75, 281.25], // S (258.75-281.25)
+            'SO2' => [281.25, 303.75], // SO (281.25-303.75)
+            'O2' => [303.75, 326.25], // O (303.75-326.25)
+            'NO2' => [326.25, 348.75], // NO (326.25-348.75)
+        ];
+
+        foreach ($directions as $direction => $range) {
+            if ($degrees >= $range[0] && $degrees < $range[1]) {
+                // Entferne die "2" Suffixe für die Rückgabe
+                return str_replace('2', '', $direction);
+            }
+        }
+
+        // Fallback für den Fall, dass nichts gefunden wird
+        return 'N';
+    }
+
     public function getGemarkungByUTM(float $utmX, float $utmY): ?array
     {
         // Basis-URL der API (neuer Endpunkt /items)

--- a/templates/founds/list.html.twig
+++ b/templates/founds/list.html.twig
@@ -145,7 +145,10 @@
                                         <strong>{{ 'next'|trans }}:</strong>
                                         {{ image.church_or_center_name|default('unbekannt') }}
                                         {% if image.distanceToChurchOrCenter is not null %}
-                                            ({{ (image.distanceToChurchOrCenter * 1000)|number_format(0, ',', '.') }} m)
+                                            ({{ (image.distanceToChurchOrCenter * 1000)|number_format(0, ',', '.') }} m
+                                            {% if image.directionToChurchOrCenter %}
+                                                {{ ('direction.' ~ image.directionToChurchOrCenter)|trans }}
+                                            {% endif %})
                                         {% endif %}
                                     </p>
                                     <p class="mb-1"><strong>{{ 'filter.utm'|trans }}:</strong> {{ image.utm|default('keine UTM Daten') }}</p>

--- a/templates/pdf/upload_report.html.twig
+++ b/templates/pdf/upload_report.html.twig
@@ -141,6 +141,12 @@
 
     <div class="mt-2">
         <strong>Lage zum Ortskern:</strong> {{ images[0].churchOrCenterName|default(images[0].nearestTown) }}<br/>
+        {% if images[0].distanceToChurchOrCenter is not null %}
+            Entfernung: {{ (images[0].distanceToChurchOrCenter * 1000)|number_format(0, ',', '.') }} m
+            {% if images[0].directionToChurchOrCenter %}
+                {{ ('direction.' ~ images[0].directionToChurchOrCenter)|trans }}
+            {% endif %}
+        {% endif %}<br/>
         (von Ortsmitte/Kirche zum Fundplatz)
     </div>
 

--- a/templates/word/upload_report.html.twig
+++ b/templates/word/upload_report.html.twig
@@ -141,6 +141,12 @@
 
     <div class="mt-2">
         <strong>Lage zum Ortskern:</strong> {{ images[0].churchOrCenterName|default(images[0].nearestTown) }}<br/>
+        {% if images[0].distanceToChurchOrCenter is not null %}
+            Entfernung: {{ (images[0].distanceToChurchOrCenter * 1000)|number_format(0, ',', '.') }} m
+            {% if images[0].directionToChurchOrCenter %}
+                {{ ('direction.' ~ images[0].directionToChurchOrCenter)|trans }}
+            {% endif %}
+        {% endif %}<br/>
         (von Ortsmitte/Kirche zum Fundplatz)
     </div>
 

--- a/tests/Service/GeoServiceBearingTest.php
+++ b/tests/Service/GeoServiceBearingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\GeoService;
+use PHPUnit\Framework\TestCase;
+
+class GeoServiceBearingTest extends TestCase
+{
+    private GeoService $geoService;
+
+    protected function setUp(): void
+    {
+        $this->geoService = new GeoService([]);
+    }
+
+    public function testCalculateBearingReturnsValidDirection(): void
+    {
+        // Test: Prüfe, ob eine gültige Himmelsrichtung zurückgegeben wird
+        $berlinLat = 52.5200;
+        $berlinLon = 13.4050;
+        $hamburgLat = 53.5511;
+        $hamburgLon = 9.9937;
+
+        $direction = $this->geoService->calculateBearing($berlinLat, $berlinLon, $hamburgLat, $hamburgLon);
+        
+        $validDirections = ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'];
+        $this->assertContains($direction, $validDirections);
+    }
+
+    public function testCalculateBearingDifferentLocations(): void
+    {
+        // Test: Verschiedene Standorte sollten verschiedene Richtungen ergeben
+        $berlinLat = 52.5200;
+        $berlinLon = 13.4050;
+        
+        $hamburgLat = 53.5511;
+        $hamburgLon = 9.9937;
+        
+        $muenchenLat = 48.1351;
+        $muenchenLon = 11.5820;
+
+        $direction1 = $this->geoService->calculateBearing($berlinLat, $berlinLon, $hamburgLat, $hamburgLon);
+        $direction2 = $this->geoService->calculateBearing($berlinLat, $berlinLon, $muenchenLat, $muenchenLon);
+        
+        // Die Richtungen sollten unterschiedlich sein
+        $this->assertNotEquals($direction1, $direction2);
+        
+        // Beide sollten gültige Himmelsrichtungen sein
+        $validDirections = ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'];
+        $this->assertContains($direction1, $validDirections);
+        $this->assertContains($direction2, $validDirections);
+    }
+
+    public function testCalculateBearingSameLocation(): void
+    {
+        // Test: Gleicher Standort sollte Fallback zurückgeben
+        $lat = 52.5200;
+        $lon = 13.4050;
+
+        $direction = $this->geoService->calculateBearing($lat, $lon, $lat, $lon);
+        $this->assertEquals('N', $direction); // Fallback für gleiche Koordinaten
+    }
+
+    public function testCalculateBearingWithZeroCoordinates(): void
+    {
+        // Test: Mit Null-Island Koordinaten
+        $lat1 = 0.0;
+        $lon1 = 0.0;
+        $lat2 = 1.0;
+        $lon2 = 1.0;
+
+        $direction = $this->geoService->calculateBearing($lat1, $lon1, $lat2, $lon2);
+        
+        $validDirections = ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'];
+        $this->assertContains($direction, $validDirections);
+    }
+}

--- a/translations/founds.de.yaml
+++ b/translations/founds.de.yaml
@@ -9,7 +9,7 @@ state: 'Bundesland'
 county: 'Landkreis'
 district: 'District'
 parcel: 'Gemarkung'
-next: 'am nächsten'
+next: 'Nahe'
 photoUploadSuccess: 'Dein Bild wurde erfolgreich hochgeladen'
 photosUploadSuccess: '%count% Bilder wurden erfolgreich hochgeladen'
 noExifData: 'Die Datei %filename% enthält keine EXIF-Daten'
@@ -20,6 +20,17 @@ noChurchFound: 'keine Kirche in der Nähe gefunden'
 noChurchOrTownFound: 'keine Kirche oder Stadt in der Nähe gefunden'
 noValidDistance: 'konnte keine Entfernung zu Stadt oder Kirche ermitteln'
 unknown: 'Unbekannt'
+
+# Himmelsrichtungen
+direction:
+  N: 'Norden'
+  NO: 'Nordosten'
+  O: 'Osten'
+  SO: 'Südosten'
+  S: 'Süden'
+  SW: 'Südwesten'
+  W: 'Westen'
+  NW: 'Nordwesten'
 usingCurrentDate: 'Für die Datei %filename% wurde das aktuelle Datum verwendet, da kein Aufnahmedatum gefunden wurde'
 
 # Neu hinzugefügte Übersetzungen aus dem Controller


### PR DESCRIPTION
- GeoService erweitert um calculateBearing() und degreesToCompass()
- FoundsImage Entity um directionToChurchOrCenter Feld erweitert
- FoundsController berechnet Himmelsrichtung bei Upload
- Templates erweitert um Himmelsrichtung-Anzeige
- Deutsche Übersetzungen für alle 8 Himmelsrichtungen hinzugefügt
- Console Command app:calculate-bearing für vorhandene Bilder
- Upload-Problem mit private property access behoben
- Template-Übersetzungsfehler korrigiert

Neue Features:
- Anzeige der Himmelsrichtung (N, NO, O, SO, S, SW, W, NW)
- Automatische Berechnung bei neuen Uploads
- Nachträgliche Berechnung für vorhandene Bilder
- Integration in PDF/Word-Reports